### PR TITLE
Avoid E_NOTICE and E_WARNING in PHP 7.1

### DIFF
--- a/lib/PHPPdf/Core/Node/Table.php
+++ b/lib/PHPPdf/Core/Node/Table.php
@@ -75,28 +75,28 @@ class Table extends Container implements Listener
         $colspan = $node->getAttribute('colspan');
 
         $isWidthRelative = strpos($width, '%') !== false;
+        $width = (float) $width;
 
         $currentWidth = 0;
         for($i=0; $i<$colspan; $i++)
         {
             $realColumnNumber = $columnNumber + $i;
-            $currentWidth += isset($this->widthsOfColumns[$realColumnNumber]) ? $this->widthsOfColumns[$realColumnNumber] : 0;
+            $currentWidth += isset($this->widthsOfColumns[$realColumnNumber]) ? (float) $this->widthsOfColumns[$realColumnNumber] : 0;
         }
-        
+
         $diff = ($width - $currentWidth)/$colspan;
-        
-        if($isWidthRelative)
-        {
-            $diff .= '%';
-        }
 
         if($diff >= 0)
         {
             for($i=0; $i<$colspan; $i++)
             {
                 $realColumnNumber = $columnNumber + $i;
-                
-                $this->widthsOfColumns[$realColumnNumber] = isset($this->widthsOfColumns[$realColumnNumber]) ? ($this->widthsOfColumns[$realColumnNumber] + $diff) : $diff;
+                $widthOfColumn = (isset($this->widthsOfColumns[$realColumnNumber]) ? ((float) $this->widthsOfColumns[$realColumnNumber]) : 0) + $diff;
+                if($isWidthRelative)
+                {
+                    $widthOfColumn .= '%';
+                }
+                $this->widthsOfColumns[$realColumnNumber] = $widthOfColumn;
             }
         }
     }


### PR DESCRIPTION
Since PHP 7.1, E_NOTICE and E_WARNING are produced if unexpected characters are found when implicitly converting a string to value. Columns with relative width now produce errors when used in arithmetic operations. A workaround is to explicitly cast string to value before doing arithmetic operations.

See https://wiki.php.net/rfc/invalid_strings_in_arithmetic